### PR TITLE
Fixed issue generated by the Mac compatibility correction.

### DIFF
--- a/create-model
+++ b/create-model
@@ -161,6 +161,9 @@ main () {
         Makefile \
         Dockerfile
 
+    # Delete backup files
+    find . -name "*.bak" -type f -delete
+
     mv model_name "$model_name"
 
     info "INITIALIZING GIT REPOSITORY"

--- a/template/docs/hack/docs.sh
+++ b/template/docs/hack/docs.sh
@@ -14,6 +14,8 @@ cp docs/*.md docs/source/md/
 sed -i.bak '0,/model_name/s//API/' docs/source/apidoc/modules.rst
 # Show package's name in the home page
 sed -i.bak '0,/project/s//model_name/' docs/source/index.rst
+# Delete backup files
+find . -name "*.bak" -type f -delete
 # Generate html docs
 make -C docs/ html
 # Clear temp files at source/md directory


### PR DESCRIPTION
Backup files are not automatically deleted in Linux. Commands to delete such files were inserted in the code. 